### PR TITLE
bind LaunchControlXL channel buttons to remote controls 3-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Early days.
 #### Novation LaunchControl XL
 - Fader is channel fader.
 - Knobs are first three remote controls.
-- Channel buttons are first 2 sends (momentary - hold down to send signal to aux).
+- Channel buttons are remote controls 3 & 4 (top right). These are momentary "stab" buttons; hold down to set remote to max. Can be used for custom sends or to enable an effect (etc).


### PR DESCRIPTION
Allows custom momentary sends/stab buttons. Previously these buttons were hard-mapped to send 1 and 2. With channel remote controls can now map to sends or anything in the channel.

<img width="397" alt="Screenshot 2024-07-09 at 10 17 26 PM" src="https://github.com/haszari/wide-bitwig-controller-extensions/assets/4167300/818af562-e944-40eb-847e-d1889e376d2d">
